### PR TITLE
Bump for 26.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Make Gradle executable
         run: chmod +x ./gradlew

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("26.1.2.build.+")
     runtimeDownload(libs.stdlib)
 }
 
@@ -48,7 +48,7 @@ paperPluginYaml {
     name = "JustEnoughPaper"
     this.version = project.version.toString()
     this.description = project.description.toString()
-    apiVersion = "1.21"
+    apiVersion = "26.1"
     main = "lol.simeon.jep.JustEnoughPaper"
     author = "DerSimeon"
     loader = "lol.simeon.jep.boot.JepPluginLoader"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ shadow = "9.3.1"
 runtask = "3.0.2"
 resourcefactory = "1.3.1"
 gremlin = "0.0.9"
-userdev = "2.0.0-beta.19"
+userdev = "2.0.0-beta.21"
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
A version bump is needed for the mod to work on 26.1. Without the version bump, the mod [fails to run](https://mclo.gs/0zjuqr3).